### PR TITLE
Fix incorrect data sent during Game Boy Player handshake

### DIFF
--- a/rumble.c
+++ b/rumble.c
@@ -128,18 +128,19 @@ static void gbp_serial_isr()
             gbp_comms.index_ = 0;
         }
 
-        if (gbp_comms.index_ > 3) {
-            gbp_comms.out_0_ = 0x8000;
-        } else {
-            if (gbp_comms.serial_in_ ==
-                (u32) ~(gbp_comms.out_1_ | (gbp_comms.out_0_ << 16))) {
-                gbp_comms.index_ += 1;
-            }
+        if (gbp_comms.index_ < 4 &&
+            gbp_comms.serial_in_ ==
+            (u32) ~(gbp_comms.out_1_ | (gbp_comms.out_0_ << 16))) {
+            gbp_comms.index_ += 1;
+        }
 
+        if (gbp_comms.index_ < 4) {
             static char const comms_handshake_data[] = {"NINTENDO"};
 
             gbp_comms.out_0_ =
                 ((const u16*)comms_handshake_data)[gbp_comms.index_];
+        } else {
+            gbp_comms.out_0_ = 0x8000;
         }
 
         gbp_comms.out_1_ = ~in_lower;


### PR DESCRIPTION
This commit fixes an out-of-bounds buffer read (due to an off by one error) that leads to the library sending the wrong response to the Game Boy Player immediately after the "NINTENDO" handshake.

After 'B0BB4F44', the GBA should send back '8000B0BB'. However, the code was actually reading past the end of the "NINTENDO" array, sending something like 'FF00B0BB' (depending on how the code is compiled).

Given that this apparently worked before, the Game Boy Player evidently doesn't verify that (or there are multiple correct answers). However, all other games I tested properly send '8000', and this is clearly the intention of the code.

---

Note that I'm unable to test this on a Game Boy Player for a little while, so if someone else could confirm that it still works, that'd be great. That being said, this makes the behavior match official games, as far as I can tell.